### PR TITLE
Add mode switcher using touchscreen gestures

### DIFF
--- a/src/scripts/extension/background.js
+++ b/src/scripts/extension/background.js
@@ -53,16 +53,25 @@ class Background extends Storage {
   }
 
   async onMessageRequest (message) {
-    const keystroke = this.checkKeystrokeValidity(message)
+    // Check for gestures
+    if (message === 'zoomin') {
+      this.set({ mode: defaults.modesKeys[this.nextModeId] })
+    } else if (message === 'zoomout') {
+      this.set({ mode: defaults.modesKeys[this.previousModeId] })
+    } else {
 
-    if (!keystroke) return false
+      // Check for keyboard events
+      const keystroke = this.checkKeystrokeValidity(message)
 
-    if (keystroke === 'toggle_pause') {
-      this.set({ pause: !this.data.pause })
-    }
+      if (!keystroke) return false
 
-    if (keystroke === 'toggle_mode') {
-      this.set({ mode: defaults.modesKeys[this.modeId] })
+      if (keystroke === 'toggle_pause') {
+        this.set({ pause: !this.data.pause })
+      }
+
+      if (keystroke === 'toggle_mode') {
+        this.set({ mode: defaults.modesKeys[this.nextModeId] })
+      }
     }
 
     return true
@@ -76,7 +85,7 @@ class Background extends Storage {
     return defaults.modesKeys.length - 1
   }
 
-  get modeId () {
+  get nextModeId () {
     let index = this.currentModeId
 
     return (index >= this.modesLength)
@@ -84,7 +93,15 @@ class Background extends Storage {
       : index + 1
   }
 
-  checkKeystrokeValidity (message) {
+  get previousModeId () {
+    let index = this.currentModeId
+
+    return (index === 0)
+      ? 0 // Do not go into stretched mode by zooming out from normal mode
+      : index - 1
+  }
+
+  checkKeystrokeValidity(message) {
     return defaults.settingsKeys
       .filter(key => key.includes('toggle'))
       .find(key => this.data[key] === message)

--- a/src/scripts/extension/inject.js
+++ b/src/scripts/extension/inject.js
@@ -3,6 +3,7 @@ import Storage from '@/helpers/Storage'
 import observe from '@/helpers/observe'
 import { classes } from '@/static/defaults'
 import Shortcut from '@/modules/shortcut'
+import Gesture from '@/modules/gesture'
 import FullscreenVideo from '@/modules/fullscreen-video'
 
 class Inject extends Storage {
@@ -11,6 +12,7 @@ class Inject extends Storage {
 
     this.fullscreen = new FullscreenVideo
     this.shortcut = new Shortcut
+    this.gesture = new Gesture
 
     this.whenFullscreenTriggers = this.whenFullscreenTriggers.bind(this)
     // this.observer = new MutationObserver(observe(this))
@@ -29,10 +31,12 @@ class Inject extends Storage {
       if (changes.pause.newValue) {
         this.cancelFullscreenEvent()
         this.cancelShortcutEvent()
+        this.cancelGestureEvent()
       }
       else {
         this.registerFullscreenEvent()
         this.registerShortcutEvent()
+        this.registerGestureEvent()
       }
     }
   }
@@ -115,6 +119,16 @@ class Inject extends Storage {
   cancelShortcutEvent () {
     this.shortcut.stopRecording()
     this.shortcut.off('fulfilled', browser.runtime.sendMessage)
+  }
+
+  registerGestureEvent () {
+    this.gesture.startRecording()
+    this.gesture.on('fulfilled', browser.runtime.sendMessage)
+  }
+
+  cancelGestureEvent () {
+    this.gesture.stopRecording()
+    this.gesture.off('fulfilled', browser.runtime.sendMessage)
   }
 }
 

--- a/src/scripts/inject.js
+++ b/src/scripts/inject.js
@@ -9,5 +9,6 @@ instance.syncData().then(data => {
   if (!data.pause) {
     instance.registerFullscreenEvent()
     instance.registerShortcutEvent()
+    instance.registerGestureEvent()
   }
 })

--- a/src/scripts/modules/gesture.js
+++ b/src/scripts/modules/gesture.js
@@ -44,12 +44,16 @@ class Gesture extends EventEmitter {
 
 
   pointerDownHandler (ev) {
+    if (ev.defaultPrevented || ev.repeat) return
+
     // The pointerdown event signals the start of a touch interaction.
     // This event is cached to support 2-finger gestures
     this.evCache.push(ev)
   }
 
   pointerMoveHandler (ev) {
+    if (ev.defaultPrevented || ev.repeat) return
+
     // This function implements a 2-pointer horizontal pinch/zoom gesture. 
     //
     // If the distance between the two pointers has increased -> zoom in, 

--- a/src/scripts/modules/gesture.js
+++ b/src/scripts/modules/gesture.js
@@ -1,0 +1,118 @@
+// Based on
+// https://github.com/mdn/dom-examples/blob/bdade19d93216597e104b02b819443a428b2dffa/pointerevents/Pinch_zoom_gestures.html
+
+import EventEmitter from 'eventemitter3'
+
+class Gesture extends EventEmitter {
+  constructor (element = document) {
+    super()
+
+    this.element = element
+
+    // Global vars to cache event state
+    this.evCache = new Array()
+    this.prevDiff = -1
+    this.trigger = true
+
+    this.onpointerdown = this.pointerdown_handler.bind(this)
+    this.onpointermove = this.pointermove_handler.bind(this)
+    this.onpointerup = this.pointerup_handler.bind(this)
+  }
+
+  startRecording () {
+    // Install event handlers for the pointer target
+    this.element.addEventListener('pointerdown', this.onpointerdown, true)
+    this.element.addEventListener('pointermove', this.onpointermove, true)
+
+    // Use same handler for pointer{up,cancel,out,leave} events since
+    // the semantics for these events - in this app - are the same.
+    this.element.addEventListener('pointerup', this.onpointerup, true)
+    this.element.addEventListener('pointercancel', this.onpointerup, true)
+    this.element.addEventListener('pointerout', this.onpointerup, true)
+    this.element.addEventListener('pointerleave', this.onpointerup, true)
+  }
+
+  stopRecording () {
+    this.element.removeEventListener('pointerdown', this.onpointerdownr, true)
+    this.element.removeEventListener('pointermove', this.onpointermove, true)
+
+    this.element.removeEventListener('pointerup', this.onpointerup, true)
+    this.element.removeEventListener('pointercancel', this.onpointerup, true)
+    this.element.removeEventListener('pointerout', this.onpointerup, true)
+    this.element.removeEventListener('pointerleave', this.onpointerup, true)
+  }
+
+
+  pointerdown_handler (ev) {
+    // The pointerdown event signals the start of a touch interaction.
+    // This event is cached to support 2-finger gestures
+    this.evCache.push(ev)
+  }
+
+  pointermove_handler (ev) {
+    // This function implements a 2-pointer horizontal pinch/zoom gesture. 
+    //
+    // If the distance between the two pointers has increased -> zoom in, 
+    // if the distance is decreasing -> zoom out
+
+    // Find this event in the cache and update its record with this event
+    for (var i = 0; i < this.evCache.length; i++) {
+      if (ev.pointerId == this.evCache[i].pointerId) {
+        this.evCache[i] = ev
+        break
+      }
+    }
+
+    // Cancel the event if the mode has been allready changed
+    if (!this.trigger) return
+
+    // If two pointers are down, check for pinch gestures
+    if (this.evCache.length == 2) {
+      // Calculate the distance between the two pointers
+      var curDiff = Math.abs(this.evCache[0].clientX - this.evCache[1].clientX);
+
+      if (this.prevDiff > 0) {
+        if (curDiff > this.prevDiff) {
+          // The distance between the two pointers has increased
+          this.emit('fulfilled', 'zoomin')
+        }
+        if (curDiff < this.prevDiff) {
+          // The distance between the two pointers has decreased
+          this.emit('fulfilled', 'zoomout')
+        }
+
+        // Prevent the event from triggering multiple times
+        if (curDiff !== this.prevDiff)
+          this.trigger = false
+      }
+
+      // Cache the distance for the next move event 
+      this.prevDiff = curDiff
+    }
+  }
+
+  pointerup_handler (ev) {
+    // Remove this pointer from the cache
+    this.remove_event(ev)
+
+    // If the number of pointers down is less than two then reset diff
+    // and reenable triggering
+    if (this.evCache.length < 2) {
+      this.prevDiff = -1
+      this.trigger = true
+    }
+  }
+
+  remove_event (ev) {
+    // Remove this event from the target's cache
+    for (var i = 0; i < this.evCache.length; i++) {
+      if (this.evCache[i].pointerId == ev.pointerId) {
+        this.evCache.splice(i, 1)
+        break
+      }
+    }
+  }
+
+}
+
+export default Gesture

--- a/src/scripts/modules/gesture.js
+++ b/src/scripts/modules/gesture.js
@@ -14,42 +14,42 @@ class Gesture extends EventEmitter {
     this.prevDiff = -1
     this.trigger = true
 
-    this.onpointerdown = this.pointerdown_handler.bind(this)
-    this.onpointermove = this.pointermove_handler.bind(this)
-    this.onpointerup = this.pointerup_handler.bind(this)
+    this.onPointerDown = this.pointerDownHandler.bind(this)
+    this.onPointerMove = this.pointerMoveHandler.bind(this)
+    this.onPointerUp = this.pointerUpHandler.bind(this)
   }
 
   startRecording () {
     // Install event handlers for the pointer target
-    this.element.addEventListener('pointerdown', this.onpointerdown, true)
-    this.element.addEventListener('pointermove', this.onpointermove, true)
+    this.element.addEventListener('pointerdown', this.onPointerDown, true)
+    this.element.addEventListener('pointermove', this.onPointerMove, true)
 
     // Use same handler for pointer{up,cancel,out,leave} events since
     // the semantics for these events - in this app - are the same.
-    this.element.addEventListener('pointerup', this.onpointerup, true)
-    this.element.addEventListener('pointercancel', this.onpointerup, true)
-    this.element.addEventListener('pointerout', this.onpointerup, true)
-    this.element.addEventListener('pointerleave', this.onpointerup, true)
+    this.element.addEventListener('pointerup', this.onPointerUp, true)
+    this.element.addEventListener('pointercancel', this.onPointerUp, true)
+    this.element.addEventListener('pointerout', this.onPointerUp, true)
+    this.element.addEventListener('pointerleave', this.onPointerUp, true)
   }
 
   stopRecording () {
-    this.element.removeEventListener('pointerdown', this.onpointerdownr, true)
-    this.element.removeEventListener('pointermove', this.onpointermove, true)
+    this.element.removeEventListener('pointerdown', this.onPointerDownr, true)
+    this.element.removeEventListener('pointermove', this.onPointerMove, true)
 
-    this.element.removeEventListener('pointerup', this.onpointerup, true)
-    this.element.removeEventListener('pointercancel', this.onpointerup, true)
-    this.element.removeEventListener('pointerout', this.onpointerup, true)
-    this.element.removeEventListener('pointerleave', this.onpointerup, true)
+    this.element.removeEventListener('pointerup', this.onPointerUp, true)
+    this.element.removeEventListener('pointercancel', this.onPointerUp, true)
+    this.element.removeEventListener('pointerout', this.onPointerUp, true)
+    this.element.removeEventListener('pointerleave', this.onPointerUp, true)
   }
 
 
-  pointerdown_handler (ev) {
+  pointerDownHandler (ev) {
     // The pointerdown event signals the start of a touch interaction.
     // This event is cached to support 2-finger gestures
     this.evCache.push(ev)
   }
 
-  pointermove_handler (ev) {
+  pointerMoveHandler (ev) {
     // This function implements a 2-pointer horizontal pinch/zoom gesture. 
     //
     // If the distance between the two pointers has increased -> zoom in, 
@@ -91,9 +91,9 @@ class Gesture extends EventEmitter {
     }
   }
 
-  pointerup_handler (ev) {
+  pointerUpHandler (ev) {
     // Remove this pointer from the cache
-    this.remove_event(ev)
+    this.removeEvent(ev)
 
     // If the number of pointers down is less than two then reset diff
     // and reenable triggering
@@ -103,7 +103,7 @@ class Gesture extends EventEmitter {
     }
   }
 
-  remove_event (ev) {
+  removeEvent (ev) {
     // Remove this event from the target's cache
     for (var i = 0; i < this.evCache.length; i++) {
       if (this.evCache[i].pointerId == ev.pointerId) {

--- a/src/scripts/modules/gesture.js
+++ b/src/scripts/modules/gesture.js
@@ -33,7 +33,7 @@ class Gesture extends EventEmitter {
   }
 
   stopRecording () {
-    this.element.removeEventListener('pointerdown', this.onPointerDownr, true)
+    this.element.removeEventListener('pointerdown', this.onPointerDown, true)
     this.element.removeEventListener('pointermove', this.onPointerMove, true)
 
     this.element.removeEventListener('pointerup', this.onPointerUp, true)

--- a/test/background.test.js
+++ b/test/background.test.js
@@ -123,7 +123,7 @@ describe('test the background', () => {
       await instance.onMessageRequest(defaults.settings.toggle_mode)
 
       const args = {
-        mode: defaults.modesKeys[instance.modeId]
+        mode: defaults.modesKeys[instance.nextModeId]
       }
 
       expect(browser.storage.local.set.called).toBe(true)
@@ -145,12 +145,12 @@ describe('test the background', () => {
 
   describe('test the modeId', () => {
     it('should return the index of the next mode' , () => {
-      expect(instance.modeId).toBe(2)
+      expect(instance.nextModeId).toBe(2)
     })
 
     it('should return zero if there are no more modes' , () => {
       defaults.modesKeys.pop()
-      expect(instance.modeId).toBe(0)
+      expect(instance.nextModeId).toBe(0)
     })
   })
 

--- a/test/background.test.js
+++ b/test/background.test.js
@@ -108,6 +108,16 @@ describe('test the background', () => {
       expect(response).toBe(true)
     })
 
+    it('should return true, if keystroke is zoomin', async () => {
+      const response = await instance.onMessageRequest('zoomin')
+      expect(response).toBe(true)
+    })
+
+    it('should return true, if keystroke is zoomout', async () => {
+      const response = await instance.onMessageRequest('zoomout')
+      expect(response).toBe(true)
+    })
+
     it('should set new value to storage for pause if keystroke is toggle_pause', async () => {
       await instance.onMessageRequest(defaults.settings.toggle_pause)
 
@@ -121,6 +131,28 @@ describe('test the background', () => {
 
     it('should set new value to storage for mode if keystroke is toggle_mode', async () => {
       await instance.onMessageRequest(defaults.settings.toggle_mode)
+
+      const args = {
+        mode: defaults.modesKeys[instance.nextModeId]
+      }
+
+      expect(browser.storage.local.set.called).toBe(true)
+      expect(browser.storage.local.set.calledWith(args)).toBe(true)
+    })
+
+    it('should set new value to storage for mode if keystroke is zoomin', async () => {
+      await instance.onMessageRequest('zoomin')
+
+      const args = {
+        mode: defaults.modesKeys[instance.nextModeId]
+      }
+
+      expect(browser.storage.local.set.called).toBe(true)
+      expect(browser.storage.local.set.calledWith(args)).toBe(true)
+    })
+
+    it('should set new value to storage for mode if keystroke is zoomout', async () => {
+      await instance.onMessageRequest('zoomout')
 
       const args = {
         mode: defaults.modesKeys[instance.nextModeId]

--- a/test/background.test.js
+++ b/test/background.test.js
@@ -143,7 +143,7 @@ describe('test the background', () => {
     })
   })
 
-  describe('test the modeId', () => {
+  describe('test the nextModeId', () => {
     it('should return the index of the next mode' , () => {
       expect(instance.nextModeId).toBe(2)
     })

--- a/test/background.test.js
+++ b/test/background.test.js
@@ -154,6 +154,16 @@ describe('test the background', () => {
     })
   })
 
+  describe('test the previousModeId', () => {
+    it('should return the index of the previous mode' , () => {
+      expect(instance.previousModeId).toBe(0)
+    })
+
+    it('should return zero if there are no more modes' , () => {
+      expect(instance.previousModeId).toBe(0)
+    })
+  })
+
   describe('test the checkKeystrokeValidity', () => {
     it('should return undefined if given value is not valid', async () => {
       const check = await instance.checkKeystrokeValidity('N+O+P+E')

--- a/test/modules/gesture.test.js
+++ b/test/modules/gesture.test.js
@@ -1,0 +1,254 @@
+import Gesture from '@/modules/gesture'
+
+// Had to use recreate PointerEvent, because jest throws
+// an error with the built in PointerEvent:
+// ReferenceError: PointerEvent is not defined
+// This class only implements the field(s) used by
+// the Gesture class
+class PointerEvent extends MouseEvent {
+  constructor(type, PointerEventInit) {
+    super(type, PointerEventInit)
+    if (PointerEventInit !== undefined) {
+      this.pointerId = PointerEventInit['pointerId']
+    }
+  }
+}
+
+describe('tests for gesture module', () => {
+  beforeAll(() => {
+    global.instance = new Gesture(document)
+  })
+
+  afterAll(() => {
+    delete global.instance
+  })
+
+  it('should be valid instance', () => {
+    expect(instance).toBeInstanceOf(Gesture)
+  })
+
+  it('should have default element if not passed as arguments', () => {
+    const customInstance = new Gesture
+
+    expect(customInstance.element).toBe(document)
+  })
+
+  it('should be possible to pass an element to the instance', () => {
+    const mockInstance = jest.fn((element) => new Gesture(element))
+
+    mockInstance(document.body)
+
+    expect(mockInstance).toHaveBeenCalledWith(document.body)
+  })
+
+  describe('test startRecording method', () => {
+    beforeEach(() => {
+      jest.spyOn(instance, 'onPointerDown')
+      jest.spyOn(instance, 'onPointerUp')
+      instance.startRecording()
+    })
+
+    afterEach(() => {
+      jest.restoreAllMocks()
+      instance.stopRecording()
+    })
+
+    it('should trigger onPointerDown when event is emitted', () => {
+      instance.element.dispatchEvent(
+        new PointerEvent('pointerdown')
+      )
+
+      expect(instance.onPointerDown).toHaveBeenCalledTimes(1)
+    })
+
+    it('should trigger onPointerUp when event is emitted', () => {
+      instance.element.dispatchEvent(
+        new PointerEvent('pointerup')
+      )
+
+      expect(instance.onPointerUp).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('test stopRecording method', () => {
+    beforeAll(() => {
+      jest.spyOn(instance, 'onPointerDown')
+      jest.spyOn(instance, 'onPointerUp')
+      instance.startRecording()
+      instance.stopRecording()
+    })
+
+    afterAll(() => {
+      jest.restoreAllMocks()
+    })
+
+    it('should not trigger onPointerDown when event is emitted', () => {
+      instance.element.dispatchEvent(
+        new PointerEvent('pointerdown')
+      )
+
+      expect(instance.onPointerDown).not.toHaveBeenCalled()
+    })
+
+    it('should trigger onPointerUp when event is emitted', () => {
+      instance.element.dispatchEvent(
+        new PointerEvent('pointerup')
+      )
+
+      expect(instance.onPointerUp).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('test onPointerUp method', () => {
+    beforeAll(() => {
+      global.instance = new Gesture(document)
+    })
+
+    afterAll(() => {
+      delete global.instance
+    })
+
+    it('should remove an event from evCache array', () => {
+      
+      var ev = new PointerEvent('pointerdown', {pointerId: 2})
+
+      instance.evCache = [
+        new PointerEvent('pointerdown', {pointerId: 1}),
+          ev,
+          new PointerEvent('pointerdown', {pointerId: 3})
+      ]
+
+      instance.removeEvent(ev)
+
+      expect(instance.evCache).not.toContain(ev)
+    })
+  })
+  describe('test onPointerDown method', () => {
+    beforeAll(() => {
+      global.instance = new Gesture(document)
+    })
+  
+    afterAll(() => {
+      delete global.instance
+    })
+    afterEach(() => {
+      jest.restoreAllMocks()
+    })
+
+    it('should not execute if event is prevented', () => {
+      jest.spyOn(instance, 'onPointerDown')
+
+      document.addEventListener('pointerdown', (e) => {
+        e.preventDefault()
+        instance.onPointerDown(e)
+      })
+
+      document.dispatchEvent(
+        new PointerEvent('pointerdown', { cancelable: true })
+      )
+
+      expect(instance.onPointerDown).toHaveReturnedWith(undefined)
+      expect(instance.evCache.length).toBe(0)
+    })
+
+    it('should add a pointer from event to the evCache array', () => {
+      var e = new PointerEvent('pointerdown')
+      instance.onPointerDown(e)
+
+      expect(instance.evCache).toEqual([e])
+    })
+  })
+
+  describe('test onPointerMove method', () => {
+    beforeAll(() => {
+      global.instance = new Gesture(document)
+    })
+      afterAll(() => {
+      delete global.instance
+    })
+    afterEach(() => {
+      jest.restoreAllMocks()
+    })
+
+    it('should calculate the difference between the event\'s clientX', () => {
+      instance.evCache = [
+        new PointerEvent('pointerdown', { clientX: 10, clientY: 10, pointerId: 1 }),
+        new PointerEvent('pointerdown', { clientX: 15, clientY: 15, pointerId: 2 })
+      ]
+
+      instance.onPointerMove(
+        new PointerEvent('pointermove', { clientX: 20, clientY: 20, pointerId: 2 })
+      )
+
+      expect(instance.prevDiff).toBe(10)
+    })
+
+    it('should emit the fulfilled event and return zoomin', () => {
+      jest.spyOn(instance, 'emit')
+
+      instance.evCache = [
+        new PointerEvent('pointerdown', { clientX: 10, clientY: 10, pointerId: 1 }),
+        new PointerEvent('pointerdown', { clientX: 15, clientY: 15, pointerId: 2 })
+      ]
+      instance.prevDiff = 5
+
+      instance.onPointerMove(
+        new PointerEvent('pointermove', { clientX: 20, clientY: 20, pointerId: 2 })
+      )
+
+      expect(instance.emit.mock.calls[0]).toContain('zoomin')
+    })
+
+    it('should emit the fulfilled event and return zoomout', () => {
+      jest.spyOn(instance, 'emit')
+
+      instance.evCache = [
+        new PointerEvent('pointerdown', { clientX: 10, clientY: 10, pointerId: 1 }),
+        new PointerEvent('pointerdown', { clientX: 15, clientY: 15, pointerId: 2 })
+      ]
+      instance.prevDiff = 5
+      instance.trigger = true
+
+      instance.onPointerMove(
+        new PointerEvent('pointermove', { clientX: 12, clientY: 12, pointerId: 2 })
+      )
+
+      expect(instance.emit.mock.calls[0]).toContain('zoomout')
+    })
+  })
+
+  describe('test onPointerUp method', () => {
+    beforeAll(() => {
+      global.instance = new Gesture(document)
+    })
+
+    afterAll(() => {
+      delete global.instance
+    })
+    afterEach(() => {
+      jest.restoreAllMocks()
+    })
+
+    it('should reset prevdiff and tigger and remove it from array of evCache', () => {
+
+      // Make some moves to perform a zoom
+      instance.evCache = [
+        new PointerEvent('pointerdown', { clientX: 10, clientY: 10, pointerId: 1 }),
+        new PointerEvent('pointerdown', { clientX: 15, clientY: 15, pointerId: 2 })
+      ]
+      instance.prevDiff = 5
+      instance.trigger = true
+
+      instance.onPointerMove(
+        new PointerEvent('pointermove', { clientX: 12, clientY: 12, pointerId: 2 })
+      )
+
+      instance.onPointerUp(new PointerEvent('pointerup', { pointerId: 1 }))
+
+      expect(instance.evCache).toHaveLength(1)
+      expect(instance.prevDiff).toBe(-1)
+      expect(instance.trigger).toBe(true)
+    })
+  })
+
+})


### PR DESCRIPTION
This should fix https://github.com/dvlden/ultrawideo/issues/15

Todo: Write tests

Tested on: 
- Firefox Nightly (v201228 17:01)
- Android 11
- YouTube

Pinch in to go to the next mode (in the order found in [defaults.js](https://github.com/dvlden/ultrawideo/blob/main/src/scripts/static/defaults.js))
Pinch out to go back to the previous mode.
Note: Pinch out won't go to stretched mode after normal, but zoom in will go to stretched after normal

There are some typos in my commit message, sorry about that. :)